### PR TITLE
chore(deps): upgrade dependencies and expand CI Node.js matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x, 26.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -25,27 +25,27 @@
   },
   "homepage": "https://mercurius.dev",
   "peerDependencies": {
-    "graphql": "^16.0.0"
+    "graphql": "^16.14.0"
   },
   "devDependencies": {
-    "@sinonjs/fake-timers": "^10.0.2",
-    "@types/node": "^20.1.0",
-    "@types/ws": "^8.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.21.0",
-    "@typescript-eslint/parser": "^5.21.0",
-    "fastify": "^5.0.0-alpha.4",
-    "graphql-ws": "^5.11.2",
-    "mercurius": "^15.0.0",
+    "@sinonjs/fake-timers": "^15.4.0",
+    "@types/node": "^25.9.1",
+    "@types/ws": "^8.18.1",
+    "@typescript-eslint/eslint-plugin": "^8.59.4",
+    "@typescript-eslint/parser": "^8.59.4",
+    "fastify": "^5.8.5",
+    "graphql-ws": "^6.0.8",
+    "mercurius": "^16.9.0",
     "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
+    "standard": "^17.1.2",
     "tap": "^16.3.0",
     "tsd": "^0.28.0",
-    "typescript": "^5.0.2"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
-    "@fastify/error": "^4.0.0",
-    "secure-json-parse": "^3.0.0",
-    "ws": "^8.2.2"
+    "@fastify/error": "^4.2.0",
+    "secure-json-parse": "^4.1.0",
+    "ws": "^8.20.1"
   },
   "tsd": {
     "directory": "test/types"


### PR DESCRIPTION
Upgrades package dependencies to the latest (excluding `tsd`),
Expands CI node matrix to support Node 20, 22, 24, and 26
Upgrades checkout/setup-node actions to v6.